### PR TITLE
Sponge plugin for wsmc/Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,18 @@
       <id>sonatype-oss</id>
       <url>https://oss.sonatype.org/content/repositories/public/</url>
     </repository>
+    <!-- https://docs.spongepowered.org/en/plugin/workspace/dependencies.html -->
+    <repository>
+      <id>sponge-maven-repo</id>
+      <name>Sponge maven repo</name>
+      <url>http://repo.spongepowered.org/maven</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <properties>
@@ -42,12 +54,22 @@
       <version>17.0</version>
       <scope>compile</scope>
     </dependency>
+
+    <!-- Bukkit/Spigot plugin -->
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
       <version>1.8.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+    <!-- SpongeForge/SpongeVanilla plugin -->
+    <dependency>
+      <groupId>org.spongepowered</groupId>
+      <artifactId>spongeapi</artifactId>
+      <version>3.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/src/main/java/deathcap/wsmc/BukkitPlayerTeller.java
+++ b/src/main/java/deathcap/wsmc/BukkitPlayerTeller.java
@@ -1,0 +1,34 @@
+package deathcap.wsmc;
+
+import org.bukkit.Bukkit;
+
+public class BukkitPlayerTeller implements PlayerTeller {
+    @Override
+    public void tellPlayer(String username, String destination, String url) {
+        if (destination == null) {
+            // console
+            String msg = "Web client enabled: "+url;
+            Bukkit.getServer().getConsoleSender().sendMessage(msg);
+        } else {
+            // player - /tellraw link
+            String raw =
+            "{" +
+                "\"text\": \"\"," + // required though unused
+                "\"extra\": [" +    // clickable link
+                "{" +
+                    "\"text\": \"Web client enabled (click to view)\"," +
+                        "\"bold\": \"true\"," +
+                        "\"clickEvent\": {" +
+                            "\"action\": \"open_url\"," +
+                            "\"value\": \"" + url + "\"" +  // TODO: json encode
+                        "}" +
+                    "}" +
+                "]" +
+            "}";
+            // TODO: switch to RichMessage API after https://github.com/Bukkit/Bukkit/pull/1065
+            //player.sendRawMessage(raw); // not what we want, actually just strips ChatColors
+            // TODO: note /tellraw Glowstone https://github.com/SpaceManiac/Glowstone/issues/124
+            Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw " + destination + " " + raw);
+        }
+    }
+}

--- a/src/main/java/deathcap/wsmc/ExternalNetworkAddressChecker.java
+++ b/src/main/java/deathcap/wsmc/ExternalNetworkAddressChecker.java
@@ -9,7 +9,20 @@ import java.net.URL;
 import java.net.UnknownHostException;
 
 public class ExternalNetworkAddressChecker {
-    public static String checkip() {
+    public static String autoConfigureIfNeeded(String externalDomain) {
+        // If 'auto', try to get external IP (hits Amazon), or if empty, get local hostname
+        // TODO: is it reasonable to contact an external server by default? Erring on the conservative side
+        if (externalDomain.equals("auto")) {
+            externalDomain = checkip();
+        }
+        if (externalDomain.equals("")) {
+            externalDomain = getHostName();
+        }
+
+        return externalDomain;
+    }
+
+    private static String checkip() {
         try {
             URL url = new URL("http://checkip.amazonaws.com/");
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(url.openStream()));
@@ -23,7 +36,7 @@ public class ExternalNetworkAddressChecker {
         return ExternalNetworkAddressChecker.getHostName();
     }
 
-    public static String getHostName() {
+    private static String getHostName() {
         try {
             return InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException ex) {

--- a/src/main/java/deathcap/wsmc/PlayerTeller.java
+++ b/src/main/java/deathcap/wsmc/PlayerTeller.java
@@ -1,0 +1,7 @@
+package deathcap.wsmc;
+
+// Generic interface to tell a player (or null for console) about a URL to click on
+
+public interface PlayerTeller {
+    public void tellPlayer(String username, String destination, String url);
+}

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -16,22 +16,20 @@ public class UserIdentityLinker implements Listener, UserAuthenticator {
     private Map<String, String> keys = new HashMap<String, String>(); // TODO: persist TODO: UUID? but need player name anyway
     private SecureRandom random = new SecureRandom();
     private final String webURL;
-    private final boolean announceOnJoin;
     private final boolean allowAnonymous;
     private final WsmcBukkitPlugin plugin;
 
-    public UserIdentityLinker(String externalScheme, String externalDomain, int externalPort, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
+    public UserIdentityLinker(String externalScheme, String externalDomain, int externalPort, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
         this(externalScheme
                 + "://"
                 + externalDomain
                 + (externalPort != 80
                 ? (":" + externalPort) : "")
-                + "/", announceOnJoin, allowAnonymous, plugin);
+                + "/", allowAnonymous, plugin);
     }
 
-    public UserIdentityLinker(String webURL, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
+    public UserIdentityLinker(String webURL, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
         this.webURL = webURL;
-        this.announceOnJoin = announceOnJoin;
         this.allowAnonymous = allowAnonymous;
         this.plugin = plugin;
     }
@@ -98,18 +96,6 @@ public class UserIdentityLinker implements Listener, UserAuthenticator {
         }
 
         return key;
-    }
-
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        if (!this.announceOnJoin) return;
-
-        Player player = event.getPlayer();
-
-        // TODO: don't show if client brand is our own
-        // TODO: option to only show on first connect
-
-        this.tellPlayer(player, player);
     }
 
     // TODO: factor these out

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -2,9 +2,7 @@ package deathcap.wsmc;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.security.SecureRandom;
 import java.util.HashMap;
@@ -98,13 +96,9 @@ public class UserIdentityLinker implements Listener, UserAuthenticator {
         return key;
     }
 
-    // TODO: factor these out
+    // TODO: factor this out
 
     // Give a player a URL to authenticate and join over the websocket
-    public void tellPlayer(Player whom, Player destination) {
-        this.tellPlayer(whom.getName(), destination.getName());
-    }
-
     public void tellPlayer(String username, String destination) {
         String key = this.getOrGenerateUserKey(username);
         String url = this.webURL+"#"+username+":"+key; // TODO: urlencode

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -1,9 +1,6 @@
 package deathcap.wsmc;
 
 import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 // Links a random "key" to the player's identity for websocket authentication
-public class UserIdentityLinker implements Listener, CommandExecutor, UserAuthenticator {
+public class UserIdentityLinker implements Listener, UserAuthenticator {
 
     private Map<String, String> keys = new HashMap<String, String>(); // TODO: persist TODO: UUID? but need player name anyway
     private SecureRandom random = new SecureRandom();
@@ -115,12 +112,14 @@ public class UserIdentityLinker implements Listener, CommandExecutor, UserAuthen
         this.tellPlayer(player, player);
     }
 
+    // TODO: factor these out
+
     // Give a player a URL to authenticate and join over the websocket
-    private void tellPlayer(Player whom, Player destination) {
+    public void tellPlayer(Player whom, Player destination) {
         this.tellPlayer(whom.getName(), destination.getName());
     }
 
-    private void tellPlayer(String username, String destination) {
+    public void tellPlayer(String username, String destination) {
         String key = this.getOrGenerateUserKey(username);
         String url = this.webURL+"#"+username+":"+key; // TODO: urlencode
         if (destination == null) {
@@ -147,34 +146,6 @@ public class UserIdentityLinker implements Listener, CommandExecutor, UserAuthen
             //player.sendRawMessage(raw); // not what we want, actually just strips ChatColors
             // TODO: note /tellraw Glowstone https://github.com/SpaceManiac/Glowstone/issues/124
             plugin.getServer().dispatchCommand(Bukkit.getConsoleSender(), "tellraw "+destination+" "+raw);
-        }
-    }
-
-    @Override
-    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
-        if (commandSender instanceof Player) {
-            Player player = (Player)commandSender;
-            this.tellPlayer(player, player);
-
-            return true;
-        } else {
-            if (args.length < 1) {
-                commandSender.sendMessage("player name required for /web");
-                return false;
-            }
-
-            String playerName = args[0];
-            /*
-            Player player = this.plugin.getServer().getPlayer(playerName);
-            if (player == null) {
-                commandSender.sendMessage("no such player "+playerName);
-                return false;
-            }
-            */
-
-            this.tellPlayer(playerName, null);
-
-            return false;
         }
     }
 }

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -23,12 +23,12 @@ public class UserIdentityLinker implements Listener, CommandExecutor, UserAuthen
     private final boolean allowAnonymous;
     private final WsmcBukkitPlugin plugin;
 
-    public UserIdentityLinker(String websocket_external_scheme, String websocket_external_domain, int websocket_external_port, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
-        this(websocket_external_scheme
+    public UserIdentityLinker(String externalScheme, String externalDomain, int externalPort, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
+        this(externalScheme
                 + "://"
-                + websocket_external_domain
-                + (websocket_external_port != 80
-                ? (":" + websocket_external_port) : "")
+                + externalDomain
+                + (externalPort != 80
+                ? (":" + externalPort) : "")
                 + "/", announceOnJoin, allowAnonymous, plugin);
     }
 

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -1,15 +1,11 @@
 package deathcap.wsmc;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
-
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 
 // Links a random "key" to the player's identity for websocket authentication
-public class UserIdentityLinker implements Listener, UserAuthenticator {
+public class UserIdentityLinker implements UserAuthenticator {
 
     private Map<String, String> keys = new HashMap<String, String>(); // TODO: persist TODO: UUID? but need player name anyway
     private SecureRandom random = new SecureRandom();

--- a/src/main/java/deathcap/wsmc/UserIdentityLinker.java
+++ b/src/main/java/deathcap/wsmc/UserIdentityLinker.java
@@ -23,6 +23,15 @@ public class UserIdentityLinker implements Listener, CommandExecutor, UserAuthen
     private final boolean allowAnonymous;
     private final WsmcBukkitPlugin plugin;
 
+    public UserIdentityLinker(String websocket_external_scheme, String websocket_external_domain, int websocket_external_port, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
+        this(websocket_external_scheme
+                + "://"
+                + websocket_external_domain
+                + (websocket_external_port != 80
+                ? (":" + websocket_external_port) : "")
+                + "/", announceOnJoin, allowAnonymous, plugin);
+    }
+
     public UserIdentityLinker(String webURL, boolean announceOnJoin, boolean allowAnonymous, WsmcBukkitPlugin plugin) {
         this.webURL = webURL;
         this.announceOnJoin = announceOnJoin;

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -67,13 +67,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
 
         saveConfig();
 
-        String url = websocket_external_scheme
-                + "://"
-                + websocket_external_domain
-                + (websocket_external_port != 80
-                    ? (":" + websocket_external_port) : "")
-                + "/";
-        users = new UserIdentityLinker(url,
+        users = new UserIdentityLinker(websocket_external_scheme, websocket_external_domain, websocket_external_port,
                 minecraft_announce_on_join,
                 minecraft_allow_anonymous,
                 this);

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -102,7 +102,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
     public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
         if (commandSender instanceof Player) {
             Player player = (Player)commandSender;
-            this.users.tellPlayer(player, player);
+            this.users.tellPlayer(player.getName(), player.getName());
 
             return true;
         } else {
@@ -136,6 +136,6 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         // TODO: don't show if client brand is our own
         // TODO: option to only show on first connect
 
-        this.users.tellPlayer(player, player);
+        this.users.tellPlayer(player.getName(), player.getName());
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -20,6 +20,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
     private WebThread webThread;
     private UserIdentityLinker users;
     private PacketFilter filter;
+    private PlayerTeller teller;
 
     boolean announceOnJoin = true;
 
@@ -67,9 +68,10 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
 
         saveConfig();
 
+        teller = new BukkitPlayerTeller();
+
         users = new UserIdentityLinker(externalScheme, externalDomain, externalPort,
-                allowAnonymous,
-                this);
+                allowAnonymous);
         getServer().getPluginManager().registerEvents(users, this);
         getCommand("web").setExecutor(this);
 
@@ -102,7 +104,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
     public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
         if (commandSender instanceof Player) {
             Player player = (Player)commandSender;
-            this.users.tellPlayer(player.getName(), player.getName());
+            this.teller.tellPlayer(player.getName(), player.getName(), this.users.getOrGenerateUserURL(player.getName()));
 
             return true;
         } else {
@@ -120,7 +122,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
             }
             */
 
-            this.users.tellPlayer(playerName, null);
+            this.teller.tellPlayer(playerName, null, this.users.getOrGenerateUserURL(playerName));
 
             return false;
         }
@@ -136,6 +138,6 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         // TODO: don't show if client brand is our own
         // TODO: option to only show on first connect
 
-        this.users.tellPlayer(player.getName(), player.getName());
+        this.teller.tellPlayer(player.getName(), player.getName(), this.users.getOrGenerateUserURL(player.getName()));
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -72,7 +72,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
 
         users = new UserIdentityLinker(externalScheme, externalDomain, externalPort,
                 allowAnonymous);
-        getServer().getPluginManager().registerEvents(users, this);
+        getServer().getPluginManager().registerEvents(this, this);
         getCommand("web").setExecutor(this);
 
         filter = new PacketFilter();

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -52,8 +52,6 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         config.addDefault("filter.whitelist", new Integer[] { }); // TODO: each direction
         config.addDefault("filter.blacklist", new Integer[] { });
 
-        externalDomain = ExternalNetworkAddressChecker.autoConfigureIfNeeded(externalDomain);
-
         verbose = this.getConfig().getBoolean("verbose");
         wsAddress = this.getConfig().getString("websocket.bind-address");
         wsPort = this.getConfig().getInt("websocket.bind-port");
@@ -64,6 +62,8 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         mcPort = this.getConfig().getInt("minecraft.connect-port");
         announceOnJoin = this.getConfig().getBoolean("minecraft.announce-on-join");
         allowAnonymous = this.getConfig().getBoolean("minecraft.allow-anonymous");
+
+        externalDomain = ExternalNetworkAddressChecker.autoConfigureIfNeeded(externalDomain);
 
         saveConfig();
 

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -8,7 +8,9 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Arrays;
@@ -18,6 +20,8 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
     private WebThread webThread;
     private UserIdentityLinker users;
     private PacketFilter filter;
+
+    boolean announceOnJoin = true;
 
     @Override
     public void onEnable() {
@@ -33,7 +37,6 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         int externalPort = 24444;
         String mcAddress = "localhost";
         int mcPort = Bukkit.getServer().getPort();
-        boolean announceOnJoin = true;
         boolean allowAnonymous = false;
 
         config.addDefault("verbose", new Boolean(verbose));
@@ -65,7 +68,6 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         saveConfig();
 
         users = new UserIdentityLinker(externalScheme, externalDomain, externalPort,
-                announceOnJoin,
                 allowAnonymous,
                 this);
         getServer().getPluginManager().registerEvents(users, this);
@@ -122,5 +124,18 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
 
             return false;
         }
+    }
+
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!this.announceOnJoin) return;
+
+        Player player = event.getPlayer();
+
+        // TODO: don't show if client brand is our own
+        // TODO: option to only show on first connect
+
+        this.users.tellPlayer(player, player);
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -45,14 +45,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
         config.addDefault("filter.whitelist", new Integer[] { }); // TODO: each direction
         config.addDefault("filter.blacklist", new Integer[] { });
 
-        // If 'auto', try to get external IP (hits Amazon), or if empty, get local hostname
-        // TODO: is it reasonable to contact an external server by default? Erring on the conservative side
-        if (this.getConfig().getString("websocket.external-domain").equals("auto")) {
-            this.getConfig().set("websocket.external-domain", ExternalNetworkAddressChecker.checkip());
-        }
-        if (this.getConfig().getString("websocket.external-domain").equals("")) {
-            this.getConfig().set("websocket.external-domain", ExternalNetworkAddressChecker.getHostName());
-        }
+        externalDomain = ExternalNetworkAddressChecker.autoConfigureIfNeeded(externalDomain);
 
         verbose = this.getConfig().getBoolean("verbose");
         wsAddress = this.getConfig().getString("websocket.bind-address");

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -138,6 +138,8 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExe
         // TODO: don't show if client brand is our own
         // TODO: option to only show on first connect
 
-        this.teller.tellPlayer(player.getName(), player.getName(), this.users.getOrGenerateUserURL(player.getName()));
+        String name = player.getName();
+
+        this.teller.tellPlayer(name, name, this.users.getOrGenerateUserURL(name));
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -3,13 +3,17 @@ package deathcap.wsmc;
 import deathcap.wsmc.mc.PacketFilter;
 import deathcap.wsmc.web.WebThread;
 import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Arrays;
 
-public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
+public class WsmcBukkitPlugin extends JavaPlugin implements Listener, CommandExecutor {
 
     private WebThread webThread;
     private UserIdentityLinker users;
@@ -65,7 +69,7 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
                 allowAnonymous,
                 this);
         getServer().getPluginManager().registerEvents(users, this);
-        getCommand("web").setExecutor(users);
+        getCommand("web").setExecutor(this);
 
         filter = new PacketFilter();
         for (int id : this.getConfig().getIntegerList("filter.whitelist")) filter.addWhitelist(id);
@@ -87,6 +91,36 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
     public void onDisable() {
         if (webThread != null) {
             webThread.interrupt();
+        }
+    }
+
+    // org.bukkit.command.CommandExecutor
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
+        if (commandSender instanceof Player) {
+            Player player = (Player)commandSender;
+            this.users.tellPlayer(player, player);
+
+            return true;
+        } else {
+            if (args.length < 1) {
+                commandSender.sendMessage("player name required for /web");
+                return false;
+            }
+
+            String playerName = args[0];
+            /*
+            Player player = this.plugin.getServer().getPlayer(playerName);
+            if (player == null) {
+                commandSender.sendMessage("no such player "+playerName);
+                return false;
+            }
+            */
+
+            this.users.tellPlayer(playerName, null);
+
+            return false;
         }
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -21,16 +21,27 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
         final FileConfiguration config = getConfig();
         config.options().copyDefaults(true);
 
-        config.addDefault("verbose", new Boolean(true));
-        config.addDefault("websocket.bind-address", "");
-        config.addDefault("websocket.bind-port", 24444);
-        config.addDefault("websocket.external-scheme", "http");
-        config.addDefault("websocket.external-domain", "");
-        config.addDefault("websocket.external-port", 24444);
-        config.addDefault("minecraft.connect-address", "localhost");
-        config.addDefault("minecraft.connect-port", Bukkit.getServer().getPort());
-        config.addDefault("minecraft.announce-on-join", true);
-        config.addDefault("minecraft.allow-anonymous", false);
+        boolean verbose = true;
+        String websocket_bind_address = "";
+        int websocket_bind_port = 24444;
+        String websocket_external_scheme = "http";
+        String websocket_external_domain = "";
+        int websocket_external_port = 24444;
+        String minecraft_connect_address = "localhost";
+        int minecraft_connect_port = Bukkit.getServer().getPort();
+        boolean minecraft_announce_on_join = true;
+        boolean minecraft_allow_anonymous = false;
+
+        config.addDefault("verbose", new Boolean(verbose));
+        config.addDefault("websocket.bind-address", websocket_bind_address);
+        config.addDefault("websocket.bind-port", websocket_bind_port);
+        config.addDefault("websocket.external-scheme", websocket_external_scheme);
+        config.addDefault("websocket.external-domain", websocket_external_domain);
+        config.addDefault("websocket.external-port", websocket_external_port);
+        config.addDefault("minecraft.connect-address", minecraft_connect_address);
+        config.addDefault("minecraft.connect-port", minecraft_connect_port);
+        config.addDefault("minecraft.announce-on-join", minecraft_announce_on_join);
+        config.addDefault("minecraft.allow-anonymous", minecraft_allow_anonymous);
         config.addDefault("filter.whitelist", new Integer[] { }); // TODO: each direction
         config.addDefault("filter.blacklist", new Integer[] { });
 
@@ -43,17 +54,28 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
             this.getConfig().set("websocket.external-domain", ExternalNetworkAddressChecker.getHostName());
         }
 
+        verbose = this.getConfig().getBoolean("verbose");
+        websocket_bind_address = this.getConfig().getString("websocket.bind-address");
+        websocket_bind_port = this.getConfig().getInt("websocket.bind-port");
+        websocket_external_scheme = this.getConfig().getString("websocket.external-scheme");
+        websocket_external_domain = this.getConfig().getString("websocket.external-domain");
+        websocket_external_port = this.getConfig().getInt("websocket.external-port");
+        minecraft_connect_address = this.getConfig().getString("minecraft.connect-address");
+        minecraft_connect_port = this.getConfig().getInt("minecraft.connect-port");
+        minecraft_announce_on_join = this.getConfig().getBoolean("minecraft.announce-on-join");
+        minecraft_allow_anonymous = this.getConfig().getBoolean("minecraft.allow-anonymous");
+
         saveConfig();
 
-        String url = this.getConfig().getString("websocket.external-scheme")
+        String url = websocket_external_scheme
                 + "://"
-                + this.getConfig().getString("websocket.external-domain")
-                + (this.getConfig().getInt("websocket.external-port") != 80
-                    ? (":" + this.getConfig().getInt("websocket.external-port")) : "")
+                + websocket_external_domain
+                + (websocket_external_port != 80
+                    ? (":" + websocket_external_port) : "")
                 + "/";
         users = new UserIdentityLinker(url,
-                this.getConfig().getBoolean("minecraft.announce-on-join"),
-                this.getConfig().getBoolean("minecraft.allow-anonymous"),
+                minecraft_announce_on_join,
+                minecraft_allow_anonymous,
                 this);
         getServer().getPluginManager().registerEvents(users, this);
         getCommand("web").setExecutor(users);
@@ -64,12 +86,12 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
 
 
         webThread = new WebThread(
-                this.getConfig().getString("websocket.bind-address"),
-                this.getConfig().getInt("websocket.bind-port"),
-                this.getConfig().getString("minecraft.connect-address"),
-                this.getConfig().getInt("minecraft.connect-port"),
+                websocket_bind_address,
+                websocket_bind_port,
+                minecraft_connect_address,
+                minecraft_connect_port,
                 users, filter,
-                this.getConfig().getBoolean("verbose")
+                verbose
                 );
         webThread.start();
     }

--- a/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcBukkitPlugin.java
@@ -22,26 +22,26 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
         config.options().copyDefaults(true);
 
         boolean verbose = true;
-        String websocket_bind_address = "";
-        int websocket_bind_port = 24444;
-        String websocket_external_scheme = "http";
-        String websocket_external_domain = "";
-        int websocket_external_port = 24444;
-        String minecraft_connect_address = "localhost";
-        int minecraft_connect_port = Bukkit.getServer().getPort();
-        boolean minecraft_announce_on_join = true;
-        boolean minecraft_allow_anonymous = false;
+        String wsAddress = "";
+        int wsPort = 24444;
+        String externalScheme = "http";
+        String externalDomain = "";
+        int externalPort = 24444;
+        String mcAddress = "localhost";
+        int mcPort = Bukkit.getServer().getPort();
+        boolean announceOnJoin = true;
+        boolean allowAnonymous = false;
 
         config.addDefault("verbose", new Boolean(verbose));
-        config.addDefault("websocket.bind-address", websocket_bind_address);
-        config.addDefault("websocket.bind-port", websocket_bind_port);
-        config.addDefault("websocket.external-scheme", websocket_external_scheme);
-        config.addDefault("websocket.external-domain", websocket_external_domain);
-        config.addDefault("websocket.external-port", websocket_external_port);
-        config.addDefault("minecraft.connect-address", minecraft_connect_address);
-        config.addDefault("minecraft.connect-port", minecraft_connect_port);
-        config.addDefault("minecraft.announce-on-join", minecraft_announce_on_join);
-        config.addDefault("minecraft.allow-anonymous", minecraft_allow_anonymous);
+        config.addDefault("websocket.bind-address", wsAddress);
+        config.addDefault("websocket.bind-port", wsPort);
+        config.addDefault("websocket.external-scheme", externalScheme);
+        config.addDefault("websocket.external-domain", externalDomain);
+        config.addDefault("websocket.external-port", externalPort);
+        config.addDefault("minecraft.connect-address", mcAddress);
+        config.addDefault("minecraft.connect-port", mcPort);
+        config.addDefault("minecraft.announce-on-join", announceOnJoin);
+        config.addDefault("minecraft.allow-anonymous", allowAnonymous);
         config.addDefault("filter.whitelist", new Integer[] { }); // TODO: each direction
         config.addDefault("filter.blacklist", new Integer[] { });
 
@@ -55,21 +55,21 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
         }
 
         verbose = this.getConfig().getBoolean("verbose");
-        websocket_bind_address = this.getConfig().getString("websocket.bind-address");
-        websocket_bind_port = this.getConfig().getInt("websocket.bind-port");
-        websocket_external_scheme = this.getConfig().getString("websocket.external-scheme");
-        websocket_external_domain = this.getConfig().getString("websocket.external-domain");
-        websocket_external_port = this.getConfig().getInt("websocket.external-port");
-        minecraft_connect_address = this.getConfig().getString("minecraft.connect-address");
-        minecraft_connect_port = this.getConfig().getInt("minecraft.connect-port");
-        minecraft_announce_on_join = this.getConfig().getBoolean("minecraft.announce-on-join");
-        minecraft_allow_anonymous = this.getConfig().getBoolean("minecraft.allow-anonymous");
+        wsAddress = this.getConfig().getString("websocket.bind-address");
+        wsPort = this.getConfig().getInt("websocket.bind-port");
+        externalScheme = this.getConfig().getString("websocket.external-scheme");
+        externalDomain = this.getConfig().getString("websocket.external-domain");
+        externalPort = this.getConfig().getInt("websocket.external-port");
+        mcAddress = this.getConfig().getString("minecraft.connect-address");
+        mcPort = this.getConfig().getInt("minecraft.connect-port");
+        announceOnJoin = this.getConfig().getBoolean("minecraft.announce-on-join");
+        allowAnonymous = this.getConfig().getBoolean("minecraft.allow-anonymous");
 
         saveConfig();
 
-        users = new UserIdentityLinker(websocket_external_scheme, websocket_external_domain, websocket_external_port,
-                minecraft_announce_on_join,
-                minecraft_allow_anonymous,
+        users = new UserIdentityLinker(externalScheme, externalDomain, externalPort,
+                announceOnJoin,
+                allowAnonymous,
                 this);
         getServer().getPluginManager().registerEvents(users, this);
         getCommand("web").setExecutor(users);
@@ -80,10 +80,10 @@ public class WsmcBukkitPlugin extends JavaPlugin implements Listener {
 
 
         webThread = new WebThread(
-                websocket_bind_address,
-                websocket_bind_port,
-                minecraft_connect_address,
-                minecraft_connect_port,
+                wsAddress,
+                wsPort,
+                mcAddress,
+                mcPort,
                 users, filter,
                 verbose
                 );

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -111,7 +111,7 @@ public class WsmcSpongePlugin implements CommandExecutor {
         CommandSpec commandSpec = CommandSpec.builder()
                 .description(Text.of("Get a per-user web URL from WebSocket-Minecraft (WSMC)"))
                 //.permission("wsmc.command.web") // TODO
-                .arguments(GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of("player")))) // TODO: change to string, since this requires the player to be online :(
+                .arguments(GenericArguments.optional(GenericArguments.string(Text.of("player"))))
                 .executor(this)
                 .build();
         Sponge.getCommandManager().register(this, commandSpec, "web");
@@ -146,15 +146,23 @@ public class WsmcSpongePlugin implements CommandExecutor {
     @Override
     public CommandResult execute(CommandSource commandSource, CommandContext commandContext) throws CommandException {
         if (commandSource instanceof Player) {
+            // If from a player, always give URL for that user TODO: allow other users if ops? permission?
+
             Player player = (Player) commandSource;
 
             this.teller.tellPlayer(player.getName(), player.getName(), this.users.getOrGenerateUserURL(player.getName()));
 
             return CommandResult.success();
-        }
+        } else {
+            String name = (String) commandContext.getOne("player").orElse(null);
+            if (name == null) {
+                commandSource.sendMessage(Text.of("player name required for /web"));
+                return CommandResult.empty();
+            }
 
-        // TODO
-        System.out.println("COMMAND: "+commandSource+" = "+commandContext);
-        return CommandResult.empty();
+            this.teller.tellPlayer(name, null, this.users.getOrGenerateUserURL(name));
+
+            return CommandResult.empty();
+        }
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -37,6 +37,9 @@ public class WsmcSpongePlugin {
         ConfigurationNode rootNode = null;
         ConfigurationOptions configurationOptions = ConfigurationOptions.defaults();
         configurationOptions.setShouldCopyDefaults(true);
+        // TODO: find out why defaults are not being copied
+        // setShouldCopyDefaults(true) is supposed to according to https://docs.spongepowered.org/en/plugin/configuration/nodes.html
+        // set the defaults if not given but I'm not seeing this happen (using SpongeAPI 3.0.0), but doing this works:
 
         try {
             rootNode = configManager.load(configurationOptions);
@@ -68,9 +71,8 @@ public class WsmcSpongePlugin {
         announceOnJoin = rootNode.getNode("minecraft", "announce-on-join").getBoolean(announceOnJoin);
         allowAnonymous = rootNode.getNode("minecraft", "allow-anonymous").getBoolean(allowAnonymous);
 
-        // TODO: find out why defaults are not being copied
-        // setShouldCopyDefaults(true) is supposed to according to https://docs.spongepowered.org/en/plugin/configuration/nodes.html
-        // set the defaults if not given but I'm not seeing this happen (using SpongeAPI 3.0.0), but doing this works:
+        externalDomain = ExternalNetworkAddressChecker.autoConfigureIfNeeded(externalDomain);
+        
         rootNode.getNode("verbose").setValue(verbose);
         rootNode.getNode("websocket", "bind-address").setValue(wsAddress);
         rootNode.getNode("websocket", "bind-port").setValue(wsPort);

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -7,6 +7,7 @@ import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
@@ -51,7 +52,8 @@ public class WsmcSpongePlugin {
         String externalDomain = "";
         int externalPort = 24444;
         String mcAddress = "localhost";
-        int mcPort = 25565; // TODO: Sponge equivalent of Bukkit.getServer().getPort()?
+        int mcPort = Sponge.getServer().getBoundAddress().isPresent() ?
+                Sponge.getServer().getBoundAddress().get().getPort() : 25565;
         boolean announceOnJoin = true;
         boolean allowAnonymous = false;
 
@@ -95,7 +97,7 @@ public class WsmcSpongePlugin {
                 this);
                 */
 
-        System.out.println("WS("+wsPort+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
+        System.out.println("WS("+wsAddress+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
 
         filter = new PacketFilter(); // TODO
 

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -1,24 +1,114 @@
 package deathcap.wsmc;
 
+import com.google.inject.Inject;
 import deathcap.wsmc.mc.PacketFilter;
 import deathcap.wsmc.web.WebThread;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.plugin.Plugin;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 @Plugin(id = "WSMC", name = "WebSocket-Minecraft Proxy", version = "0.0.1")
 public class WsmcSpongePlugin {
 
+    // https://docs.spongepowered.org/en/plugin/configuration/index.html
+    @Inject
+    @DefaultConfig(sharedRoot = true)
+    private Path defaultConfig;
+
+    @Inject
+    @DefaultConfig(sharedRoot = true)
+    private ConfigurationLoader<CommentedConfigurationNode> configManager;
+
+    private WebThread webThread;
+    //private UserIdentityLinker users; // TODO
+    private PacketFilter filter;
+
     @Listener
     public void onServerStart(GameStartedServerEvent event) {
-        // TODO: get from configuration file, Sponge-style
+        ConfigurationNode rootNode = null;
+        ConfigurationOptions configurationOptions = ConfigurationOptions.defaults();
+        configurationOptions.setShouldCopyDefaults(true);
+
+        try {
+            rootNode = configManager.load(configurationOptions);
+        } catch (IOException ex) {
+            System.out.println("wsmc failed to load configuration: " + ex.getLocalizedMessage());
+            ex.printStackTrace();
+        }
+
+        boolean verbose = true;
         String wsAddress = "";
         int wsPort = 24444;
+        String externalScheme = "http";
+        String externalDomain = "";
+        int externalPort = 24444;
         String mcAddress = "localhost";
-        int mcPort = 25565; // TODO: get from server port
+        int mcPort = 25565; // TODO: Sponge equivalent of Bukkit.getServer().getPort()?
+        boolean announceOnJoin = true;
+        boolean allowAnonymous = false;
 
-        System.out.println("WS("+wsAddress+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
-        WebThread webThread = new WebThread(wsAddress, wsPort, mcAddress, mcPort, null, new PacketFilter(), true);
+        verbose = rootNode.getNode("verbose").getBoolean(verbose);
+        wsAddress = rootNode.getNode("websocket", "bind-address").getString(wsAddress);
+        wsPort = rootNode.getNode("websocket", "bind-port").getInt(wsPort);
+        externalScheme = rootNode.getNode("websocket", "external-scheme").getString(externalScheme);
+        externalDomain = rootNode.getNode("websocket", "external-domain").getString(externalDomain);
+        externalPort = rootNode.getNode("websocket", "external-port").getInt(externalPort);
+        mcAddress = rootNode.getNode("minecraft", "connect-address").getString(mcAddress);
+        mcPort = rootNode.getNode("minecraft", "connect-port").getInt(mcPort);
+        announceOnJoin = rootNode.getNode("minecraft", "announce-on-join").getBoolean(announceOnJoin);
+        allowAnonymous = rootNode.getNode("minecraft", "allow-anonymous").getBoolean(allowAnonymous);
+
+        // TODO: find out why defaults are not being copied
+        // setShouldCopyDefaults(true) is supposed to according to https://docs.spongepowered.org/en/plugin/configuration/nodes.html
+        // set the defaults if not given but I'm not seeing this happen (using SpongeAPI 3.0.0), but doing this works:
+        rootNode.getNode("verbose").setValue(verbose);
+        rootNode.getNode("websocket", "bind-address").setValue(wsAddress);
+        rootNode.getNode("websocket", "bind-port").setValue(wsPort);
+        rootNode.getNode("websocket", "external-scheme").setValue(externalScheme);
+        rootNode.getNode("websocket", "external-domain").setValue(externalDomain);
+        rootNode.getNode("websocket", "external-port").setValue(externalPort);
+        rootNode.getNode("minecraft", "connect-address").setValue(mcAddress);
+        rootNode.getNode("minecraft", "connect-port").setValue(mcPort);
+        rootNode.getNode("minecraft", "announce-on-join").setValue(announceOnJoin);
+        rootNode.getNode("minecraft", "allow-anonymous").setValue(allowAnonymous);
+
+        try {
+            configManager.save(rootNode);
+        } catch (IOException ex) {
+            System.out.println("wsmc failed to save configuration: " + ex.getLocalizedMessage());
+            ex.printStackTrace();
+        }
+
+        /* TODO: add UserIdentityLinker to Sponge - need to refactor out messaging user (not Bukkit plugin)
+        users = null;
+        new UserIdentityLinker(externalScheme, externalDomain, externalPort,
+                announceOnJoin,
+                allowAnonymous,
+                this);
+                */
+
+        System.out.println("WS("+wsPort+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
+
+        filter = new PacketFilter(); // TODO
+
+        webThread = new WebThread(
+                wsAddress,
+                wsPort,
+                mcAddress,
+                mcPort,
+                null, //users, // TODO
+                filter,
+                verbose
+        );
+
         webThread.start();
     }
 }

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -1,0 +1,24 @@
+package deathcap.wsmc;
+
+import deathcap.wsmc.mc.PacketFilter;
+import deathcap.wsmc.web.WebThread;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameStartedServerEvent;
+import org.spongepowered.api.plugin.Plugin;
+
+@Plugin(id = "WSMC", name = "WebSocket-Minecraft Proxy", version = "0.0.1")
+public class WsmcSpongePlugin {
+
+    @Listener
+    public void onServerStart(GameStartedServerEvent event) {
+        // TODO: get from configuration file, Sponge-style
+        String wsAddress = "";
+        int wsPort = 24444;
+        String mcAddress = "localhost";
+        int mcPort = 25565; // TODO: get from server port
+
+        System.out.println("WS("+wsAddress+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
+        WebThread webThread = new WebThread(wsAddress, wsPort, mcAddress, mcPort, null, new PacketFilter(), true);
+        webThread.start();
+    }
+}

--- a/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
+++ b/src/main/java/deathcap/wsmc/WsmcSpongePlugin.java
@@ -12,13 +12,16 @@ import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -101,9 +104,18 @@ public class WsmcSpongePlugin implements CommandExecutor {
         }
 
         teller = new SpongePlayerTeller();
-        
+
         users = new UserIdentityLinker(externalScheme, externalDomain, externalPort,
                 allowAnonymous);
+
+        CommandSpec commandSpec = CommandSpec.builder()
+                .description(Text.of("Get a per-user web URL from WebSocket-Minecraft (WSMC)"))
+                //.permission("wsmc.command.web") // TODO
+                .arguments(GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of("player")))) // TODO: change to string, since this requires the player to be online :(
+                .executor(this)
+                .build();
+        Sponge.getCommandManager().register(this, commandSpec, "web");
+
 
         System.out.println("WS("+wsAddress+":"+wsPort+") <--> MC("+mcAddress+":"+mcPort+")");
 
@@ -135,8 +147,14 @@ public class WsmcSpongePlugin implements CommandExecutor {
     public CommandResult execute(CommandSource commandSource, CommandContext commandContext) throws CommandException {
         if (commandSource instanceof Player) {
             Player player = (Player) commandSource;
+
+            this.teller.tellPlayer(player.getName(), player.getName(), this.users.getOrGenerateUserURL(player.getName()));
+
+            return CommandResult.success();
         }
+
         // TODO
+        System.out.println("COMMAND: "+commandSource+" = "+commandContext);
         return CommandResult.empty();
     }
 }


### PR DESCRIPTION
https://github.com/deathcap/wsmc/issues/7 SpongeAPI plugin in wsmc/Java

References:
https://docs.spongepowered.org/en/plugin/index.html

* [x] Sponge API dependency
* [x] Simple plugin loading into WSMC
* [x] Read configuration file
* [x] Get server port from server instance
* [x] Configure default external address (refactor with Bukkit plugin)
* [x] Refactor UserIdentityLinker to allow Sponge
* [x] Send messages (/tellraw click link)
* [x] Handle the `/web` command, from user and console
* [x] Add announce on player join